### PR TITLE
update RandLib.cc

### DIFF
--- a/src/RandLib.cc
+++ b/src/RandLib.cc
@@ -125,7 +125,6 @@ int RandLib::multinomial(double *p, int ncat)
 ///this function should return numbers from the range inclusive  of the endpoints
 int RandLib::unirange(int maxval)
 {
-  int rv;
   double uni;
   uni = runif(0.0,maxval);
   //  cerr << "uni "<<uni<<endl;


### PR DESCRIPTION
While compiling the GitHub source, I'm getting this warning:
```
RandLib.cc:128:7: warning: unused variable 'rv' [-Wunused-variable]
  int rv;
```
removing `int rv` removes the warnings.
Allan, is this ok ? The `rv` variable is no longer used in that part of the code...

Best
Thierry