### PR TITLE
Update Landscape.cc

### DIFF
--- a/src/Landscape.cc
+++ b/src/Landscape.cc
@@ -1139,7 +1139,7 @@ void Landscape::HabCarry(int k)
 
 void Landscape::LambdaAdjust(int bypop)
 {
-  int i, j, k, l, bigto, bigfrom;
+  int i, j, k, l = 0, bigto, bigfrom;
   double pred_l, sim_l, adjrate;
   TransMat diag, Spopmat, Rpopmat;
   if (bypop)


### PR DESCRIPTION
While compiling I'm getting this warning:
```
Landscape.cc:1180:27: warning: variable 'l' is uninitialized when used here [-Wuninitialized]
              CarryState((int)(I[l].size()*adjrate+0.5),l);
```

The propose change, if it's ok with you, fixes the warning.
Thierry